### PR TITLE
fixes syntax error preventing sql-load-parts (#16)

### DIFF
--- a/Makefile.smartdumps
+++ b/Makefile.smartdumps
@@ -219,7 +219,6 @@ mysql-load-file= bash -c "(							\
 # Show time and line
 OUTPUT_INTERVAL = 50
 inter-out-filter = stdbuf -oL awk '							\
-
 	BEGIN {										\
 		pt = systime();								\
 	}										\


### PR DESCRIPTION
Deleted newline that prevented `make sql-load-parts` from running. Fixes #16.
